### PR TITLE
Adds a as_blocks to the export types.

### DIFF
--- a/lib/rqrcode.rb
+++ b/lib/rqrcode.rb
@@ -14,3 +14,4 @@ require "rqrcode/qrcode"
 require 'rqrcode/export/png'
 require 'rqrcode/export/svg'
 require 'rqrcode/export/html'
+require 'rqrcode/export/blocks'

--- a/lib/rqrcode/export/blocks.rb
+++ b/lib/rqrcode/export/blocks.rb
@@ -1,0 +1,20 @@
+module RQRCode
+  module Export
+    module Blocks
+      def as_blocks(options={})
+        blocks = StringIO.new
+        self.modules.each_index do |c|
+          self.modules.each_index do |r|
+            blocks << ( self.is_dark(c,r) ? '██' : '  ' )
+          end
+
+          blocks << "\n"
+        end
+
+        blocks.string
+      end
+    end
+  end
+end
+
+RQRCode::QRCode.send :include, RQRCode::Export::Blocks

--- a/test/test_rqrcode.rb
+++ b/test/test_rqrcode.rb
@@ -87,11 +87,11 @@ class QRCodeTest < Test::Unit::TestCase
                  qr.to_s( :true => 'q', :false => 'n' )[0..21]
     assert_equal "@@@@@@@ @@ @  @@@@@@@\n", qr.to_s( :true => '@' )[0..21]
   end
-  
+
   def test_auto_alphanumeric
     # Overflowws without the alpha version
     assert RQRCode::QRCode.new( '1234567890', :size => 1, :level => :h )
-    
+
     qr = RQRCode::QRCode.new( 'DUNCAN', :size => 1, :level => :h )
     assert_equal "xxxxxxx xxx   xxxxxxx\n", qr.to_s[0..21]
   end

--- a/test/test_rqrcode.rb
+++ b/test/test_rqrcode.rb
@@ -87,11 +87,11 @@ class QRCodeTest < Test::Unit::TestCase
                  qr.to_s( :true => 'q', :false => 'n' )[0..21]
     assert_equal "@@@@@@@ @@ @  @@@@@@@\n", qr.to_s( :true => '@' )[0..21]
   end
-
+  
   def test_auto_alphanumeric
     # Overflowws without the alpha version
     assert RQRCode::QRCode.new( '1234567890', :size => 1, :level => :h )
-
+    
     qr = RQRCode::QRCode.new( 'DUNCAN', :size => 1, :level => :h )
     assert_equal "xxxxxxx xxx   xxxxxxx\n", qr.to_s[0..21]
   end

--- a/test/test_rqrcode_export.rb
+++ b/test/test_rqrcode_export.rb
@@ -19,7 +19,7 @@ require_relative "../lib/rqrcode"
 describe :QRCodeExportTest do
   # require_relative "data"
 
-  [:svg, :png, :html].each do |ext|
+  [:svg, :png, :html, :blocks].each do |ext|
     it "must respond_to #{ext}" do
       RQRCode::QRCode.new('x').must_respond_to :"as_#{ext}"
     end
@@ -37,4 +37,7 @@ describe :QRCodeExportTest do
     RQRCode::QRCode.new('html').as_html.must_match(/<table>.+<\/table>/)
   end
 
+  it "must export to blocks" do
+    RQRCode::QRCode.new('blocks').as_blocks.must_match(/█/)
+  end
 end


### PR DESCRIPTION
( Not sure how useful this could be, but it could be used within a `<pre>`, a small font and line-height: 0; )