### PR TITLE
Simplifies PNG export, removes ChunkyPNG resizing

### DIFF
--- a/lib/rqrcode/export/png.rb
+++ b/lib/rqrcode/export/png.rb
@@ -9,11 +9,11 @@ module RQRCode
       # Render the PNG from the Qrcode.
       #
       # Options:
-      # fill            - Background ChunkyPNG::Color, defaults to 'white'
-      # color           - Foreground ChunkyPNG::Color, defaults to 'black'
-      # size            - Total size of PNG, in pixels
-      # border_modules  - Width of white border around the data portion of the code
-      # file            - Filepath of output PNG
+      # fill                    - Background ChunkyPNG::Color, defaults to 'white'
+      # color                   - Foreground ChunkyPNG::Color, defaults to 'black'
+      # size/resize_exactly_to  - Total size of PNG, in pixels
+      # border_modules          - Width of white border around the data portion of the code
+      # file                    - Filepath of output PNG
       #
       def as_png(options = {})
 
@@ -31,7 +31,7 @@ module RQRCode
         color  = ChunkyPNG::Color(options[:color])
         output_file = options[:file]
 
-        total_image_size = options[:size]
+        total_image_size = options[:resize_exactly_to] || options[:size]
         border_modules = options[:border_modules]
 
         module_px_size = (total_image_size.to_f / (self.module_count + 2 * border_modules).to_f).floor.to_i


### PR DESCRIPTION
I've noticed that when specifying the `resize_exactly_to` option to `as_png` the resulting image would often be slightly distorted. For example, the following 

```
image = RQRCode::QRCode.new("http://facebook.com", level: :l).as_png(resize_exactly_to: 80)
```
would produce the image
![chunky_resize](https://cloud.githubusercontent.com/assets/138067/7251471/d6c613fa-e7f9-11e4-94eb-0e941bb6ffbe.png)
Notice the varying thickness around the position squares.

I've noticed that other QRCode generators (e.g. Google's now deprecated Charts API) don't have this issue so this is my attempt at fixing it.

This pull request removes the `resize_exactly_to` option in favour of `size` to make it more consistent with the other exporters. It also removes the call to ChunkyPNG's `resize` and instead accomplishes exact sizing by varying the amount of border space around the data portion of the code (similar to how Google's Chart API does it). So now, the following
```
image = RQRCode::QRCode.new("http://facebook.com", level: :l).as_png(size: 80)
```
will produce the image
![simplified_resize](https://cloud.githubusercontent.com/assets/138067/7251639/45b6ec84-e7fb-11e4-92d8-0657775cc57c.png)
