### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email       = ["darwin@bits2life.com"]
   s.homepage    = "https://github.com/bjornblomqvist/rqrcode"
   s.summary     = "A library to encode QR Codes"
+  s.license     = "MIT"
   s.description = <<EOF
 rQRCode is a library for encoding QR Codes. The simple
 interface allows you to create QR Code data structures


### PR DESCRIPTION
Hi. I'm working on [VerisonEye](https://www.versioneye.com/) and I try to create a database with complete license information about all Ruby Gems. to reduce the manual work I'm currently doing, it would be great if the license information would be included in the gemspec.
